### PR TITLE
Create Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_comunity.md
+++ b/.github/ISSUE_TEMPLATE/bug_comunity.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report (Comunity)
+about: Report a bug to help us improve
+labels: bug, external
+---
+
+## Bug Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain the problem.
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/bug_team.md
+++ b/.github/ISSUE_TEMPLATE/bug_team.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report (Team Members)
+about: Report a bug for internal tracking
+labels: bug, internal
+---
+
+## Bug Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain the problem.
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_comunity.md
+++ b/.github/ISSUE_TEMPLATE/feature_comunity.md
@@ -1,0 +1,17 @@
+---
+name: New Feature Request (Comunity)
+about: Suggest a new feature to enhance the project
+labels: enhancement, external
+---
+
+## Feature Description
+
+A clear and concise description of the feature you're proposing.
+
+## Why is this feature important?
+
+Explain why this feature is important and how it will benefit the project.
+
+## Additional Context
+
+Any other context or screenshots about the feature request.

--- a/.github/ISSUE_TEMPLATE/feature_team.md
+++ b/.github/ISSUE_TEMPLATE/feature_team.md
@@ -1,0 +1,28 @@
+---
+name: New Feature Request (Team Members)
+about: Suggest a new feature for internal discussion
+labels: enhancement, internal
+---
+
+## Feature Title
+
+A concise title for the new feature.
+
+## User Stories
+
+As a [user type], I want [an action] so that [benefit/value].
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Technical Details
+
+- API Changes:
+- Database Changes:
+- Dependencies:
+
+## Additional Context
+
+Any other internal context or references.

--- a/.github/ISSUE_TEMPLATE/question_comunity.md
+++ b/.github/ISSUE_TEMPLATE/question_comunity.md
@@ -1,0 +1,17 @@
+---
+name: Question (Comunity)
+about: Ask a question or seek clarification on project-related matters (External Use)
+labels: question, external
+---
+
+## Your Question
+
+Please provide as much detail as possible so we can fully understand your question.
+
+## Why are you asking?
+
+Explain why this question is important and how it affects your interaction with the project.
+
+## Additional Context
+
+Any other context or screenshots about the question.

--- a/.github/ISSUE_TEMPLATE/question_team.md
+++ b/.github/ISSUE_TEMPLATE/question_team.md
@@ -1,0 +1,17 @@
+---
+name: Question (Team Members)
+about: Ask a question or seek clarification on project-related matters (Internal Use)
+labels: question, internal
+---
+
+## Your Question
+
+Please provide as much detail as possible so we can fully understand your question.
+
+## Why are you asking?
+
+Explain why this question is important and how it affects the project or team.
+
+## Additional Information
+
+Any other internal context or references.


### PR DESCRIPTION
## Overviews of implementation
Created issue templates for both team members and community (public contributors and users).

## Details
- Created 6 template files in the .github/ISSUE_TEMPLATE directory
- File naming convention
  - For team members: `<issue_type>_team.md`
  - For comunity: `<issue_type>_community.md`
- Created the new labels called "external" and "internal" for issues and PRs
- Labels specified in YAML format on each template are expected to be applied to issues on creation

Referenced: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

> Issue templates are stored on the repository's default branch, in a hidden .github/ISSUE_TEMPLATE directory. If you create a template in another branch, it will not be available for collaborators to use. Issue template filenames are not case sensitive, and need a .md extension. Issue templates created with issue forms need a .yml extension. To be displayed with a  checkmark in the community profile checklist, issue templates must be located in the .github/ISSUE_TEMPLATE folder and contain valid name: and about: keys in the YAML frontmatter (for issue templates defined in .md files) or valid name: and description: keys (for issue forms defined in .yml files).

## Additional Context
- Although `question_team.md` might not be used so often, I created it for the purpose of consistency with the community.
- These templates may need to be applied for other repositories, such as https://github.com/genesis-tech-tribe/nishiki-backend and https://github.com/genesis-tech-tribe/nishiki-documents.