### PR TITLE
29 make the api mock server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM stoplight/prism:5
+
+# get the latest OAS file from nishiki-document repo
+RUN wget https://raw.githubusercontent.com/genesis-tech-tribe/nishiki-documents/c1ea7d5a2fd12e1271551fc672b7141f5777ffdf/web-api/nishiki-web-api.yaml \
+&& mv nishiki-web-api.yaml /tmp/api.yml

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Run Mock Server
+
+Run the WebAPI mock server:
+
+```bash
+npm run mock
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  prism:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: 'mock -h 0.0.0.0 /tmp/api.yml'
+    ports:
+      # Serve the mocked API locally as available on port 8080
+      - '8080:4010'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "eslint --ext .ts,.js,.tsx . --fix && prettier --write \"./**/*.{ts,js,tsx,scss}\"",
     "format": "prettier --write './**/*.{js,ts,tsx,scss}'",
     "prepare": "husky install",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "mock": "docker compose up -d --build"
   },
   "dependencies": {
     "next": "13.5.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write './**/*.{js,ts,tsx,scss}'",
     "prepare": "husky install",
     "typecheck": "tsc --noEmit",
-    "mock": "docker compose up -d --build"
+    "mock": "docker compose up --build"
   },
   "dependencies": {
     "next": "13.5.4",


### PR DESCRIPTION
## Overviews of implementation

added docker-compose.yaml and Dockerfile to run the API mock server based on Nishiki-document's OAS

## Review points

Ensure that the mock server can start by `npm run mock` command, and you can get a response when you access [http://localhost:8080/users/aaa](http://localhost:8080/users/aaa)

