### PR TITLE
Refactor React imports to named import

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { siteConfig } from '@/const/site/siteConfig';
 import { cn } from '@/lib/tailwind/utils';
 
 import { Metadata } from 'next';
+import { ReactNode } from 'react';
 
 export const metadata: Metadata = {
   title: {
@@ -22,7 +23,7 @@ export const metadata: Metadata = {
 };
 
 interface RootLayoutProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export default function RootLayout({ children }: RootLayoutProps) {

--- a/src/components/base/layouts/MobileLayout.tsx
+++ b/src/components/base/layouts/MobileLayout.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { FC, ReactNode } from 'react';
 
 import { BottomTab, MobileHeader } from '../parts';
 
 interface Props {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-export const MobileLayout: React.FC<Props> = ({ children }) => {
+export const MobileLayout: FC<Props> = ({ children }) => {
   return (
     <div className="relative flex min-h-screen flex-col">
       <MobileHeader />

--- a/src/components/base/parts/mobile/MobileHeader.tsx
+++ b/src/components/base/parts/mobile/MobileHeader.tsx
@@ -2,7 +2,7 @@
 
 import { Icon } from '@/components/ui';
 
-import React from 'react';
+import React, { ButtonHTMLAttributes, FC, ReactNode } from 'react';
 
 export const MobileHeader = () => {
   return (
@@ -19,11 +19,11 @@ export const MobileHeader = () => {
   );
 };
 
-interface IButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode;
+interface IButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
 }
 
-const Button: React.FC<IButtonProps> = ({ children, ...props }) => {
+const Button: FC<IButtonProps> = ({ children, ...props }) => {
   return (
     <button className="h-full aspect-square flex items-center justify-center" {...props}>
       {children}

--- a/src/components/ui/BottomTabIconLink.tsx
+++ b/src/components/ui/BottomTabIconLink.tsx
@@ -2,7 +2,7 @@ import { mainRouteConfig, MainRouteName } from '@/const/site/mainRouteConfig';
 import { cn } from '@/lib/tailwind/utils';
 
 import Link from 'next/link';
-import React from 'react';
+import React, { FC } from 'react';
 
 import { Icon } from '.';
 import { IconName } from './Icon';
@@ -12,7 +12,7 @@ interface Props {
   isSelected: boolean;
 }
 
-export const BottomTabIconLink: React.FC<Props> = ({ name, isSelected }) => {
+export const BottomTabIconLink: FC<Props> = ({ name, isSelected }) => {
   // Path and link title based on "mainRouteConfig" variable
   const path = mainRouteConfig[name].path;
   const title = mainRouteConfig[name].title;

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/assets/images/icons';
 import { cn } from '@/lib/tailwind/utils';
 
-import React from 'react';
+import React, { FC } from 'react';
 
 const icons = {
   arrowLeft: ArrowLeftIcon,
@@ -68,7 +68,7 @@ type IconProps = {
   className?: string;
 };
 
-export const Icon: React.FC<IconProps> = ({ iconName, color, size = 'md', className }) => {
+export const Icon: FC<IconProps> = ({ iconName, color, size = 'md', className }) => {
   const IconComponent = icons[iconName];
 
   // stroke style doesn't work if you set it stroke-colorname,

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,4 +1,6 @@
+import { FC, SVGAttributes } from 'react';
+
 declare module '*.svg' {
-  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+  const content: FC<SVGAttributes<SVGElement>>;
   export default content;
 }

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,4 +1,4 @@
 declare module '*.svg' {
-  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+  const content: React.FC<React.SVGAttributes<SVGElement>>;
   export default content;
 }

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,6 +1,4 @@
-import { FC, SVGAttributes } from 'react';
-
 declare module '*.svg' {
-  const content: FC<SVGAttributes<SVGElement>>;
+  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   export default content;
 }


### PR DESCRIPTION
## Overview 
Refactored the import statements with named imports

## Note
- `import` and `export` do not work expectedly in `.d.ts` file