### PR TITLE
Enabled PR check workflow on draft PRs

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -2,7 +2,7 @@ name: PR Workflow
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     branches:
       - develop
       - main
@@ -11,7 +11,6 @@ jobs:
   check:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: checkout


### PR DESCRIPTION
## Overview

Enabled PR check workflow on draft PRs to ensure successful build before requesting reviews.

## Note
- I have confirmed that it got triggered on draft PR by pushing an empty commit.