### PR TITLE
Create a build workflow

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -38,3 +38,34 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+  build:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get Source Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Cache npm
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run mock server
+        run: npm run mock
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,4 +1,4 @@
-name: PR Workflow
+name: PR Checks
 
 on:
   pull_request:
@@ -8,27 +8,33 @@ on:
       - main
 
 jobs:
-  check:
-    timeout-minutes: 30
+  test:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout
+      - name: Get Source Code
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - name: setup node.js environment
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: install
+      - name: Cache npm
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Dependencies
         run: npm ci
 
-      - name: typecheck
+      - name: Typecheck
         run: npm run typecheck
 
-      - name: lint
+      - name: Lint
         run: npm run lint

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -65,7 +65,7 @@ jobs:
         run: npm ci
 
       - name: Run mock server
-        run: npm run mock
+        run: npm run mock:bg
 
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepare": "husky install",
     "typecheck": "tsc --noEmit",
     "mock": "docker compose up --build",
-    "mock:down": "docker compose down"
+    "mock:bg": "docker compose up --build -d",
+    "mock-down": "docker compose down"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.5",


### PR DESCRIPTION
## Overview
This PR adds a GitHub workflow that performs a build process.

## Changes
- Modified names of the file, workflow, jobs and steps
- Added the step that caches NPM dependencies
- Added `npm run mock:bg` to the workflow
- Added the `build` job that runs the mock server and builds the code afterward