### PR TITLE
Feature/92 create reusable Input components

### DIFF
--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -44,8 +44,10 @@ interface IIconProps extends VariantProps<typeof iconVariants> {
   className?: string;
 }
 
-export const Icon: FC<IIconProps> = ({ icon, className, size, color }) => {
+const Icon: FC<IIconProps> = ({ icon, className, size, color }) => {
   const IconComponent = icon;
 
   return <IconComponent className={cn(iconVariants({ color, size, className }))} />;
 };
+
+export { Icon, iconVariants };

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -15,8 +15,8 @@ const inputVariants = cva('flex w-full text-base focus:outline-none disabled:cur
     variant: {
       // naming of each variant should be aligned with the design team
       rounded: 'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray',
-      muted: 'bg-transparent border-none placeholder:text-gray',
-      square: 'bg-gray-lightest border-b border-primary pr-2 py-2',
+      muted: 'bg-transparent border-none placeholder:text-gray ',
+      square: 'bg-gray-lightest border-b border-primary p-2',
     },
     h: {
       sm: 'h-10',

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -1,0 +1,48 @@
+/**
+ * This file is based on the Input component from shadcn and customized for our needs.
+ *
+ * See the official docs for more info:
+ * shadcn/ui: https://ui.shadcn.com/docs/components/input
+ */
+
+import { cn } from '@/lib/tailwind/utils';
+
+import { cva, VariantProps } from 'class-variance-authority';
+import { forwardRef, InputHTMLAttributes } from 'react';
+
+const inputVariants = cva(
+  'flex w-full h-full text-base focus:outline-none disabled:cursor-not-allowed',
+  {
+    variants: {
+      variant: {
+        // naming of each variant should be aligned with the design team
+        rounded: 'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray',
+        muted: 'border-none placeholder:text-gray',
+        square: 'bg-gray-lightest border-b border-primary pr-2 py-2',
+      },
+    },
+    defaultVariants: {
+      variant: 'rounded',
+    },
+  },
+);
+
+export interface IInputProps
+  extends InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {}
+
+const Input = forwardRef<HTMLInputElement, IInputProps>(
+  ({ className, variant, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(inputVariants({ variant, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input, inputVariants };

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -10,33 +10,36 @@ import { cn } from '@/lib/tailwind/utils';
 import { cva, VariantProps } from 'class-variance-authority';
 import { forwardRef, InputHTMLAttributes } from 'react';
 
-const inputVariants = cva(
-  'flex w-full h-full text-base focus:outline-none disabled:cursor-not-allowed',
-  {
-    variants: {
-      variant: {
-        // naming of each variant should be aligned with the design team
-        rounded: 'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray',
-        muted: 'border-none placeholder:text-gray',
-        square: 'bg-gray-lightest border-b border-primary pr-2 py-2',
-      },
+const inputVariants = cva('flex w-full text-base focus:outline-none disabled:cursor-not-allowed', {
+  variants: {
+    variant: {
+      // naming of each variant should be aligned with the design team
+      rounded: 'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray',
+      muted: 'bg-transparent border-none placeholder:text-gray',
+      square: 'bg-gray-lightest border-b border-primary pr-2 py-2',
     },
-    defaultVariants: {
-      variant: 'rounded',
+    h: {
+      sm: 'h-10',
+      md: 'h-12',
     },
   },
-);
+
+  defaultVariants: {
+    variant: 'rounded',
+    h: 'md',
+  },
+});
 
 export interface IInputProps
   extends InputHTMLAttributes<HTMLInputElement>,
     VariantProps<typeof inputVariants> {}
 
 const Input = forwardRef<HTMLInputElement, IInputProps>(
-  ({ className, variant, type, ...props }, ref) => {
+  ({ className, variant, type, h, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(inputVariants({ variant, className }))}
+        className={cn(inputVariants({ variant, h, className }))}
         ref={ref}
         {...props}
       />

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -15,7 +15,7 @@ const inputVariants = cva('flex w-full text-base focus:outline-none disabled:cur
     variant: {
       // naming of each variant should be aligned with the design team
       rounded:
-        'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray focus:border-2 focus:border-primary-dark ',
+        'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray focus:ring-2 focus:ring-primary-dark focus:border-transparent ',
       square: 'bg-gray-lightest border-b border-primary p-2',
     },
     h: {

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -14,7 +14,8 @@ const inputVariants = cva('flex w-full text-base focus:outline-none disabled:cur
   variants: {
     variant: {
       // naming of each variant should be aligned with the design team
-      rounded: 'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray',
+      rounded:
+        'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray focus:border-2 focus:border-primary-dark ',
       muted: 'bg-transparent border-none placeholder:text-gray ',
       square: 'bg-gray-lightest border-b border-primary p-2',
     },

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -16,7 +16,6 @@ const inputVariants = cva('flex w-full text-base focus:outline-none disabled:cur
       // naming of each variant should be aligned with the design team
       rounded:
         'rounded-full bg-white border border-gray px-6 py-4 placeholder:text-gray focus:border-2 focus:border-primary-dark ',
-      muted: 'bg-transparent border-none placeholder:text-gray ',
       square: 'bg-gray-lightest border-b border-primary p-2',
     },
     h: {

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -5,7 +5,7 @@
 
 import { Input, SearchInput } from '..';
 
-export function InputWithLabelUsageExample() {
+export function InputUsageExample() {
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
       <Input type="text" id="groupName" placeholder="Group name" />

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -3,7 +3,7 @@
  * Once you're done with the example, you can delete this file.
  */
 
-import { Input, SearchInput } from '..';
+import { Input, NumberInput, SearchInput } from '..';
 
 export function InputUsageExample() {
   return (
@@ -11,8 +11,7 @@ export function InputUsageExample() {
       <Input type="text" id="groupName" placeholder="Group name" />
       <SearchInput placeholder="Search Foods" />
       <div className="w-1/2">
-        {/* When it's type number, it allows input like 01111 */}
-        <Input type="number" id="quantity" placeholder="Quantity" />
+        <NumberInput id="quantity" placeholder="Quantity" />
       </div>
     </div>
   );

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -15,6 +15,8 @@ export function InputUsageExample() {
       <div className="w-1/2">
         <Label htmlFor="quantity">Quantity</Label>
         <NumberInput id="quantity" placeholder="Quantity" />
+        {/* By default input component is excluding dot, but you can modify it  */}
+        <NumberInput id="quantity" placeholder="Quantity" exceptionSymbols={{ exceptDot: true }} />
       </div>
     </div>
   );

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -1,5 +1,5 @@
 /**
- * This file is used as an example for the Dialog component.
+ * This file is used as an example for the Input component.
  * Once you're done with the example, you can delete this file.
  */
 

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -9,6 +9,7 @@ export function InputUsageExample() {
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
       <Input type="text" id="groupName" placeholder="Group name" />
+      <Input variant={'square'} type="text" id="groupName" />
       <SearchInput placeholder="Search Foods" />
       <div className="w-1/2">
         <NumberInput id="quantity" placeholder="Quantity" />

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -3,7 +3,7 @@
  * Once you're done with the example, you can delete this file.
  */
 
-import { Input, NumberInput, SearchInput } from '..';
+import { Input, Label, NumberInput, SearchInput } from '..';
 
 export function InputUsageExample() {
   return (
@@ -12,6 +12,7 @@ export function InputUsageExample() {
       <Input variant={'square'} type="text" id="groupName" />
       <SearchInput placeholder="Search Foods" />
       <div className="w-1/2">
+        <Label>aaaa</Label>
         <NumberInput id="quantity" placeholder="Quantity" />
       </div>
     </div>

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -16,7 +16,11 @@ export function InputUsageExample() {
         <Label htmlFor="quantity">Quantity</Label>
         <NumberInput id="quantity" placeholder="Quantity" />
         {/* By default input component is excluding dot, but you can modify it  */}
-        <NumberInput id="quantity" placeholder="Quantity" exceptionSymbols={{ exceptDot: true }} />
+        <NumberInput
+          id="quantity"
+          placeholder="Quantity"
+          exceptionSymbolsProps={{ exceptDot: true }}
+        />
       </div>
     </div>
   );

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -8,7 +8,7 @@ import { Input, NumberInput, SearchInput } from './';
 
 export function InputUsageExample() {
   return (
-    <div className="grid w-full max-w-sm items-center gap-1.5">
+    <div className="grid w-full max-w-sm items-center gap-1.5 py-4">
       <Input type="text" id="groupName" placeholder="Group name" />
       <Input variant="square" type="text" id="groupName" />
       <SearchInput placeholder="Search Foods" />

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -3,7 +3,8 @@
  * Once you're done with the example, you can delete this file.
  */
 
-import { Input, Label, NumberInput, SearchInput } from '..';
+import { Label } from '../';
+import { Input, NumberInput, SearchInput } from './';
 
 export function InputUsageExample() {
   return (

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -1,0 +1,19 @@
+/**
+ * This file is used as an example for the Dialog component.
+ * Once you're done with the example, you can delete this file.
+ */
+
+import { Input, SearchInput } from '..';
+
+export function InputWithLabelUsageExample() {
+  return (
+    <div className="grid w-full max-w-sm items-center gap-1.5">
+      <Input type="text" id="groupName" placeholder="Group name" />
+      <SearchInput placeholder="Search Foods" />
+      <div className="w-1/2">
+        {/* When it's type number, it allows input like 01111 */}
+        <Input type="number" id="quantity" placeholder="Quantity" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -9,7 +9,7 @@ export function InputUsageExample() {
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
       <Input type="text" id="groupName" placeholder="Group name" />
-      <Input variant={'square'} type="text" id="groupName" />
+      <Input variant="square" type="text" id="groupName" />
       <SearchInput placeholder="Search Foods" />
       <div className="w-1/2">
         <Label>aaaa</Label>

--- a/src/components/ui/Input/InputUsageExample.tsx
+++ b/src/components/ui/Input/InputUsageExample.tsx
@@ -1,6 +1,6 @@
 /**
- * This file is used as an example for the Input component.
- * Once you're done with the example, you can delete this file.
+ * This file is used as an example for the Input components.
+ * Once we're done with the example, we can delete this file.
  */
 
 import { Label } from '../';
@@ -13,7 +13,7 @@ export function InputUsageExample() {
       <Input variant="square" type="text" id="groupName" />
       <SearchInput placeholder="Search Foods" />
       <div className="w-1/2">
-        <Label>aaaa</Label>
+        <Label htmlFor="quantity">Quantity</Label>
         <NumberInput id="quantity" placeholder="Quantity" />
       </div>
     </div>

--- a/src/components/ui/Input/NumberInput.tsx
+++ b/src/components/ui/Input/NumberInput.tsx
@@ -56,9 +56,12 @@ const handleExceptionSymbols = (
     event.preventDefault();
   }
 };
+
+const defaultVariant = 'rounded';
+
 export const NumberInput: FC<INumberInputProps> = ({
   className,
-  variant = 'rounded',
+  variant = defaultVariant,
   onKeyDown = handleExceptionSymbols,
   exceptDot = true,
   exceptE = true,

--- a/src/components/ui/Input/NumberInput.tsx
+++ b/src/components/ui/Input/NumberInput.tsx
@@ -17,8 +17,9 @@ interface IExceptionSymbolsProps {
 
 interface INumberInputProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>,
-    VariantProps<typeof inputVariants>,
-    IExceptionSymbolsProps {}
+    VariantProps<typeof inputVariants> {
+  exceptionSymbolsProps?: Partial<IExceptionSymbolsProps>;
+}
 
 const SYMBOLS = {
   zero: '0',
@@ -48,16 +49,19 @@ const handleExceptionSymbols = (
 
 const defaultVariant = 'rounded';
 
+const defaultExceptionSymbols: IExceptionSymbolsProps = {
+  exceptDot: false,
+  exceptE: true,
+  exceptLeadingZero: true,
+  exceptNegative: true,
+  exceptPlusOperator: true,
+};
+
 export const NumberInput: FC<INumberInputProps> = ({
   className,
   variant = defaultVariant,
   onKeyDown = handleExceptionSymbols,
-  // accept decimal numbers by default
-  exceptDot = false,
-  exceptE = true,
-  exceptLeadingZero = true,
-  exceptNegative = true,
-  exceptPlusOperator = true,
+  exceptionSymbolsProps = defaultExceptionSymbols,
   ...props
 }) => {
   return (
@@ -65,9 +69,7 @@ export const NumberInput: FC<INumberInputProps> = ({
       type="number"
       variant={variant}
       className={cn('flex-1', className)}
-      onKeyDown={(e) =>
-        onKeyDown(e, { exceptDot, exceptE, exceptLeadingZero, exceptNegative, exceptPlusOperator })
-      }
+      onKeyDown={(e) => onKeyDown(e, exceptionSymbolsProps)}
       {...props}
     />
   );

--- a/src/components/ui/Input/NumberInput.tsx
+++ b/src/components/ui/Input/NumberInput.tsx
@@ -1,0 +1,81 @@
+/**
+ * This file is based on the Input component from shadcn and customized for our needs.
+ *
+ * See the official docs for more info:
+ * shadcn/ui: https://ui.shadcn.com/docs/components/input
+ */
+
+'use client';
+
+import { cn } from '@/lib/tailwind/utils';
+
+import { VariantProps } from 'class-variance-authority';
+import { FC, InputHTMLAttributes } from 'react';
+
+import { Input, inputVariants } from './Input';
+
+interface IExceptionSymbolsProps {
+  exceptLeadingZero?: boolean;
+  exceptNegative?: boolean;
+  exceptPlusOperator?: boolean;
+  exceptE?: boolean;
+  exceptDot?: boolean;
+}
+
+interface INumberInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>,
+    VariantProps<typeof inputVariants>,
+    IExceptionSymbolsProps {}
+
+const zero = '0';
+const negative = '-';
+const plus = '+';
+const e = ['e', 'E'];
+const dot = '.';
+
+const handleExceptionSymbols = (
+  event: React.KeyboardEvent<HTMLInputElement>,
+  exceptionSymbolsProps: IExceptionSymbolsProps,
+) => {
+  const { key } = event;
+  const { exceptDot, exceptE, exceptLeadingZero, exceptNegative, exceptPlusOperator } =
+    exceptionSymbolsProps;
+  if (exceptDot && key === dot) {
+    event.preventDefault();
+  }
+  if (exceptE && e.includes(key)) {
+    event.preventDefault();
+  }
+  if (exceptLeadingZero && key === zero && event.currentTarget.value === zero) {
+    event.preventDefault();
+  }
+  if (exceptNegative && key === negative) {
+    event.preventDefault();
+  }
+  if (exceptPlusOperator && key === plus) {
+    event.preventDefault();
+  }
+};
+export const NumberInput: FC<INumberInputProps> = ({
+  className,
+  variant = 'rounded',
+  onKeyDown = handleExceptionSymbols,
+  exceptDot = true,
+  exceptE = true,
+  exceptLeadingZero = true,
+  exceptNegative = true,
+  exceptPlusOperator = true,
+  ...props
+}) => {
+  return (
+    <Input
+      type={'number'}
+      variant={variant}
+      className={cn('flex-1', className)}
+      onKeyDown={(e) =>
+        onKeyDown(e, { exceptDot, exceptE, exceptLeadingZero, exceptNegative, exceptPlusOperator })
+      }
+      {...props}
+    />
+  );
+};

--- a/src/components/ui/Input/NumberInput.tsx
+++ b/src/components/ui/Input/NumberInput.tsx
@@ -1,10 +1,3 @@
-/**
- * This file is based on the Input component from shadcn and customized for our needs.
- *
- * See the official docs for more info:
- * shadcn/ui: https://ui.shadcn.com/docs/components/input
- */
-
 'use client';
 
 import { cn } from '@/lib/tailwind/utils';
@@ -27,32 +20,28 @@ interface INumberInputProps
     VariantProps<typeof inputVariants>,
     IExceptionSymbolsProps {}
 
-const zero = '0';
-const negative = '-';
-const plus = '+';
-const e = ['e', 'E'];
-const dot = '.';
+const SYMBOLS = {
+  zero: '0',
+  negative: '-',
+  plus: '+',
+  e: ['e', 'E'],
+  dot: '.',
+};
 
 const handleExceptionSymbols = (
   event: React.KeyboardEvent<HTMLInputElement>,
   exceptionSymbolsProps: IExceptionSymbolsProps,
 ) => {
-  const { key } = event;
+  const { key, currentTarget } = event;
   const { exceptDot, exceptE, exceptLeadingZero, exceptNegative, exceptPlusOperator } =
     exceptionSymbolsProps;
-  if (exceptDot && key === dot) {
-    event.preventDefault();
-  }
-  if (exceptE && e.includes(key)) {
-    event.preventDefault();
-  }
-  if (exceptLeadingZero && key === zero && event.currentTarget.value === zero) {
-    event.preventDefault();
-  }
-  if (exceptNegative && key === negative) {
-    event.preventDefault();
-  }
-  if (exceptPlusOperator && key === plus) {
+  if (
+    (exceptDot && key === SYMBOLS.dot) ||
+    (exceptE && SYMBOLS.e.includes(key)) ||
+    (exceptLeadingZero && key === SYMBOLS.zero && currentTarget.value === SYMBOLS.zero) ||
+    (exceptNegative && key === SYMBOLS.negative) ||
+    (exceptPlusOperator && key === SYMBOLS.plus)
+  ) {
     event.preventDefault();
   }
 };
@@ -63,7 +52,8 @@ export const NumberInput: FC<INumberInputProps> = ({
   className,
   variant = defaultVariant,
   onKeyDown = handleExceptionSymbols,
-  exceptDot = true,
+  // accept decimal numbers by default
+  exceptDot = false,
   exceptE = true,
   exceptLeadingZero = true,
   exceptNegative = true,
@@ -72,7 +62,7 @@ export const NumberInput: FC<INumberInputProps> = ({
 }) => {
   return (
     <Input
-      type={'number'}
+      type="number"
       variant={variant}
       className={cn('flex-1', className)}
       onKeyDown={(e) =>

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -1,10 +1,3 @@
-/**
- * This file is based on the Input component from shadcn and customized for our needs.
- *
- * See the official docs for more info:
- * shadcn/ui: https://ui.shadcn.com/docs/components/input
- */
-
 'use client';
 
 import { SearchIcon } from '@/assets/images/icons';

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -5,44 +5,51 @@
  * shadcn/ui: https://ui.shadcn.com/docs/components/input
  */
 
+'use client';
+
 import { SearchIcon } from '@/assets/images/icons';
 import { cn } from '@/lib/tailwind/utils';
 
 import { VariantProps } from 'class-variance-authority';
-import { FC, InputHTMLAttributes, SVGAttributes } from 'react';
+import { FC, InputHTMLAttributes, useRef } from 'react';
 
-import { Icon, iconVariants } from '..';
+import { Icon, iconVariants } from '../';
 import { Input, inputVariants } from './Input';
 
-interface ISearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  icon?: FC<SVGAttributes<SVGElement>>;
+interface ISearchInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   iconProps?: VariantProps<typeof iconVariants>;
 }
-
-const defaultType = 'search';
-
-const defaultIcon = SearchIcon;
 
 const defaultIconProps: VariantProps<typeof iconVariants> = {
   size: 4,
   color: 'gray',
 };
 
-export const SearchInput: FC<ISearchInputProps> = (
-  { className, type = defaultType, icon = defaultIcon, iconProps = defaultIconProps, ...props },
-  ref,
-) => {
+export const SearchInput: FC<ISearchInputProps> = ({
+  className,
+  iconProps = defaultIconProps,
+  ...props
+}) => {
   const { color: iconColor, size: iconSize } = iconProps;
+
+  // logic to focus the input when the user clicks on the container
+  const ref = useRef<HTMLInputElement>(null);
+  const focusInput = () => {
+    if (ref.current) {
+      ref.current.focus();
+    }
+  };
   return (
-    <div className={cn('flex items-center', inputVariants({ variant: 'rounded' }))}>
-      <Icon icon={icon} color={iconColor} size={iconSize} className="mr-2" />
-      <Input
-        type={type}
-        variant={'muted'}
-        className={cn('flex-1', className)}
-        ref={ref}
-        {...props}
-      />
+    <div
+      className={cn(
+        'flex items-center cursor-text',
+        inputVariants({ variant: 'rounded' }),
+        className,
+      )}
+      onClick={focusInput}
+    >
+      <Icon icon={SearchIcon} color={iconColor} size={iconSize} className="mr-2" />
+      <Input type="search" variant="muted" className={'flex-1'} {...props} ref={ref} />
     </div>
   );
 };

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -7,7 +7,7 @@ import { VariantProps } from 'class-variance-authority';
 import { FC, InputHTMLAttributes, useRef } from 'react';
 
 import { Icon, iconVariants } from '../';
-import { Input, inputVariants } from './Input';
+import { Input } from './Input';
 
 interface ISearchInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   iconProps?: VariantProps<typeof iconVariants>;
@@ -30,17 +30,11 @@ export const SearchInput: FC<ISearchInputProps> = ({
       ref.current.focus();
     }
   };
+
   return (
-    <div
-      className={cn(
-        'flex items-center cursor-text',
-        inputVariants({ variant: 'rounded' }),
-        className,
-      )}
-      onClick={focusInput}
-    >
-      <Icon icon={SearchIcon} {...iconProps} className="mr-2" />
-      <Input type="search" variant="muted" className="flex-1" {...props} ref={ref} />
+    <div className={cn('relative', className)} onClick={focusInput}>
+      <Icon icon={SearchIcon} {...iconProps} className="absolute top-4 left-6" />
+      <Input type="search" variant="rounded" className="pl-12" ref={ref} {...props} />
     </div>
   );
 };

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -9,15 +9,17 @@ import { SearchIcon } from '@/assets/images/icons';
 import { cn } from '@/lib/tailwind/utils';
 
 import { VariantProps } from 'class-variance-authority';
-import { FC, InputHTMLAttributes, ReactNode } from 'react';
+import { FC, InputHTMLAttributes, SVGAttributes } from 'react';
 
 import { Icon, iconVariants } from '..';
 import { Input, inputVariants } from './Input';
 
 interface ISearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  icon?: ReactNode;
+  icon?: FC<SVGAttributes<SVGElement>>;
   iconProps?: VariantProps<typeof iconVariants>;
 }
+
+const defaultType = 'search';
 
 const defaultIcon = SearchIcon;
 
@@ -27,7 +29,7 @@ const defaultIconProps: VariantProps<typeof iconVariants> = {
 };
 
 export const SearchInput: FC<ISearchInputProps> = (
-  { className, type = 'search', icon = defaultIcon, iconProps = defaultIconProps, ...props },
+  { className, type = defaultType, icon = defaultIcon, iconProps = defaultIconProps, ...props },
   ref,
 ) => {
   const { color: iconColor, size: iconSize } = iconProps;

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -1,0 +1,46 @@
+/**
+ * This file is based on the Input component from shadcn and customized for our needs.
+ *
+ * See the official docs for more info:
+ * shadcn/ui: https://ui.shadcn.com/docs/components/input
+ */
+
+import { SearchIcon } from '@/assets/images/icons';
+import { cn } from '@/lib/tailwind/utils';
+
+import { VariantProps } from 'class-variance-authority';
+import { FC, InputHTMLAttributes, ReactNode } from 'react';
+
+import { Icon, iconVariants } from '..';
+import { Input, inputVariants } from './Input';
+
+interface ISearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  icon?: ReactNode;
+  iconProps?: VariantProps<typeof iconVariants>;
+}
+
+const defaultIcon = SearchIcon;
+
+const defaultIconProps: VariantProps<typeof iconVariants> = {
+  size: 4,
+  color: 'gray',
+};
+
+export const SearchInput: FC<ISearchInputProps> = (
+  { className, type = 'search', icon = defaultIcon, iconProps = defaultIconProps, ...props },
+  ref,
+) => {
+  const { color: iconColor, size: iconSize } = iconProps;
+  return (
+    <div className={cn('flex items-center', inputVariants({ variant: 'rounded' }))}>
+      <Icon icon={icon} color={iconColor} size={iconSize} className="mr-2" />
+      <Input
+        type={type}
+        variant={'muted'}
+        className={cn('flex-1', className)}
+        ref={ref}
+        {...props}
+      />
+    </div>
+  );
+};

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -42,7 +42,7 @@ export const SearchInput: FC<ISearchInputProps> = ({
       onClick={focusInput}
     >
       <Icon icon={SearchIcon} color={iconColor} size={iconSize} className="mr-2" />
-      <Input type="search" variant="muted" className={'flex-1'} {...props} ref={ref} />
+      <Input type="search" variant="muted" className="flex-1" {...props} ref={ref} />
     </div>
   );
 };

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -23,8 +23,6 @@ export const SearchInput: FC<ISearchInputProps> = ({
   iconProps = defaultIconProps,
   ...props
 }) => {
-  const { color: iconColor, size: iconSize } = iconProps;
-
   // logic to focus the input when the user clicks on the container
   const ref = useRef<HTMLInputElement>(null);
   const focusInput = () => {
@@ -41,7 +39,7 @@ export const SearchInput: FC<ISearchInputProps> = ({
       )}
       onClick={focusInput}
     >
-      <Icon icon={SearchIcon} color={iconColor} size={iconSize} className="mr-2" />
+      <Icon icon={SearchIcon} {...iconProps} className="mr-2" />
       <Input type="search" variant="muted" className="flex-1" {...props} ref={ref} />
     </div>
   );

--- a/src/components/ui/Input/index.ts
+++ b/src/components/ui/Input/index.ts
@@ -1,0 +1,2 @@
+export { Input } from './Input';
+export { SearchInput } from './SearchInput';

--- a/src/components/ui/Input/index.ts
+++ b/src/components/ui/Input/index.ts
@@ -1,2 +1,3 @@
 export { Input } from './Input';
+export { NumberInput } from './NumberInput';
 export { SearchInput } from './SearchInput';

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -5,6 +5,8 @@
  * shadcn/ui: https://ui.shadcn.com/docs/components/label
  * Radix UI: https://www.radix-ui.com/primitives/docs/components/label
  */
+
+'use client';
 import { cn } from '@/lib/tailwind/utils';
 
 import { Root as PrimitiveRoot } from '@radix-ui/react-label';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -28,7 +28,8 @@ export {
   DrawerTrigger,
   DrawerVariants,
 } from './Drawer';
-export { Icon } from './Icon';
+export { Icon, iconVariants } from './Icon';
+export { Input, SearchInput } from './Input';
 export { Label } from './Label';
 export {
   SelectionDrawerButton,

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -29,7 +29,7 @@ export {
   DrawerVariants,
 } from './Drawer';
 export { Icon, iconVariants } from './Icon';
-export { Input, SearchInput } from './Input';
+export { Input, NumberInput, SearchInput } from './Input';
 export { Label } from './Label';
 export {
   SelectionDrawerButton,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  input[type='search']::-webkit-search-cancel-button {
+    display: none;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,6 +4,11 @@
 
 @layer base {
   input[type='search']::-webkit-search-cancel-button {
-    display: none;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+  input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,7 @@ module.exports = {
       borderRadius: {
         xs: '0.125rem', // 2px
         sm: '0.25rem', // 4px
+        full: '3.125rem', // 50px
         DEFAULT: '0.625rem', // 10px
       },
       keyframes: {
@@ -76,5 +77,12 @@ module.exports = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [
+    require('tailwindcss-animate'),
+    require('tailwindcss/plugin')(function ({ addBase }) {
+      addBase({
+        '[type="search"]::-webkit-search-cancel-button': { display: 'none' },
+      });
+    }),
+  ],
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,7 +23,7 @@ module.exports = {
       borderRadius: {
         xs: '0.125rem', // 2px
         sm: '0.25rem', // 4px
-        full: '3.125rem', // 50px
+        full: '9999px',
         DEFAULT: '0.625rem', // 10px
       },
       keyframes: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,7 +23,6 @@ module.exports = {
       borderRadius: {
         xs: '0.125rem', // 2px
         sm: '0.25rem', // 4px
-        full: '9999px',
         DEFAULT: '0.625rem', // 10px
       },
       keyframes: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -77,12 +77,5 @@ module.exports = {
       },
     },
   },
-  plugins: [
-    require('tailwindcss-animate'),
-    require('tailwindcss/plugin')(function ({ addBase }) {
-      addBase({
-        '[type="search"]::-webkit-search-cancel-button': { display: 'none' },
-      });
-    }),
-  ],
+  plugins: [require('tailwindcss-animate')],
 };


### PR DESCRIPTION
## Overview

1. Implemented "Input" component
2. Based on it, implemented "SearchInput" component and "NumberInput" component


## Review Points
- I'll write a comment on each parts where I especially want you to take a look at. 

## Note
- Decided to create SearchInput component separately from Input component, because to add Search Icon, we needed to wrap input tag with div tag, which is unnecessary for normal inputs. Didn't want to make Input component too complex.

- Decided to create NumberInput component separately from Input component, because to default input with type "number" accept "e","E","+","-",and leading zero. We needed some logic to except these inputs when we want, and this logic will be unnecessary for normal inputs. Didn't want to make Input component too complex.

## Screenshots

### Input(Rounded), search input, number input
https://github.com/genesis-tech-tribe/nishiki-frontend/assets/99339182/53dcb512-0f79-4f58-9350-6604f4af584a

### Input(Square)
https://github.com/genesis-tech-tribe/nishiki-frontend/assets/99339182/501af181-419a-4bda-be92-6bbd0104ba4a





