### PR TITLE
Created Badge components

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,31 @@
+/**
+ * This file is based on the Badge component from shadcn and customized for our needs.
+ *
+ * See the official docs for more info:
+ * shadcn/ui: https://ui.shadcn.com/docs/components/badge
+ */
+import { cn } from '@/lib/tailwind/utils';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { HTMLAttributes } from 'react';
+
+const badgeVariants = cva('inline-flex items-center rounded-full text-sm h-6 px-3.5', {
+  variants: {
+    variant: {
+      light: 'bg-primary-light',
+      lightest: 'bg-primary-lightest',
+      outline: 'bg-gray-lightest border border-primary text-primary',
+    },
+  },
+  defaultVariants: {
+    variant: 'light',
+  },
+});
+
+interface IBadgeProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+const Badge = ({ className, variant, ...props }: IBadgeProps) => {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props}></div>;
+};
+
+export { Badge, badgeVariants };

--- a/src/components/ui/BadgeUsageExample.tsx
+++ b/src/components/ui/BadgeUsageExample.tsx
@@ -1,0 +1,33 @@
+/**
+ * This file is used as an example for the Badge, FilterBadge and CategoryBadge components.
+ * Once you're done with the example, you can delete this file.
+ */
+import { ContainerIcon, HomeIcon_Off } from '@/assets/images/icons';
+import { Badge } from '@/components/ui';
+import { foodCategories } from '@/const/foodCategory';
+import { CategoryBadge, FilterBadge } from '@/features/foods/components';
+
+export const BadgeUsageExample = () => {
+  return (
+    <div className="p-4 pr-0 bg-white">
+      <div className="flex flex-wrap gap-1 mb-1">
+        <Badge variant="light">Light</Badge>
+        <Badge variant="lightest">Lightest</Badge>
+        <Badge variant="outline">Outline</Badge>
+      </div>
+      <div className="flex gap-1 mb-1 overflow-x-auto">
+        <FilterBadge icon={HomeIcon_Off} text="Group" />
+        <FilterBadge icon={ContainerIcon} text="Container" />
+        <FilterBadge emoji={foodCategories.vegetables.emoji} text="Vegetables" />
+      </div>
+      <div className="flex flex-wrap gap-1 mb-1">
+        {Object.entries(foodCategories).map(([key, value]) => {
+          return <CategoryBadge key={key} emoji={value.emoji} text={value.name}></CategoryBadge>;
+        })}
+      </div>
+      <div className="flex flex-wrap gap-1">
+        <Badge variant="outline">3 added</Badge>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -9,6 +9,7 @@ const iconVariants = cva('', {
     // Since some of the icons in the design are not following 4px grid, and to be fixed in the future,
     // If the size in the design is not in the list, you can assign the closest size from this list.
     size: {
+      2: 'w-2 h-2',
       3: 'w-3 h-3',
       3.5: 'w-3.5 h-3.5',
       4: 'w-4 h-4',

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,4 @@
+export { Badge, badgeVariants } from './Badge';
 export { BottomTabIconLink } from './BottomTabIconLink';
 export { Button, buttonVariants } from './Button';
 export { Card } from './Card';

--- a/src/const/foodCategory.ts
+++ b/src/const/foodCategory.ts
@@ -1,0 +1,71 @@
+interface IFoodCategory {
+  name: string;
+  emoji: string;
+}
+
+interface IFoodCategories {
+  [key: string]: IFoodCategory;
+}
+
+export const foodCategories: IFoodCategories = {
+  unselected: {
+    name: 'Unselected',
+    emoji: '🥣',
+  },
+  beverage: {
+    name: 'Beverage',
+    emoji: '☕️',
+  },
+  dairy: {
+    name: 'Dairy',
+    emoji: '🥛',
+  },
+  eggs: {
+    name: 'Eggs',
+    emoji: '🥚',
+  },
+  fats: {
+    name: 'Fats',
+    emoji: '🫒',
+  },
+  fruits: {
+    name: 'Fruits',
+    emoji: '🍎',
+  },
+  vegetables: {
+    name: 'Vegetables',
+    emoji: '🥕',
+  },
+  legumes: {
+    name: 'Legumes',
+    emoji: '🫘',
+  },
+  nutsAndSeeds: {
+    name: 'Nuts & Seeds',
+    emoji: '🥜',
+  },
+  meat: {
+    name: 'Meat',
+    emoji: '🥩',
+  },
+  desserts: {
+    name: 'Desserts',
+    emoji: '🍰',
+  },
+  soup: {
+    name: 'Soup',
+    emoji: '🍜',
+  },
+  seafood: {
+    name: 'Seafood',
+    emoji: '🍣',
+  },
+  convenience: {
+    name: 'Convenience',
+    emoji: '🥡',
+  },
+  other: {
+    name: 'Other',
+    emoji: '🍽️',
+  },
+};

--- a/src/features/foods/components/CategoryBadge.tsx
+++ b/src/features/foods/components/CategoryBadge.tsx
@@ -1,0 +1,27 @@
+import { CrossIcon } from '@/assets/images/icons';
+import { Icon } from '@/components/ui';
+import { Badge } from '@/components/ui/Badge';
+import { cn } from '@/lib/tailwind/utils';
+
+interface ICategoryBadgeProps {
+  emoji: string;
+  text: string;
+  className?: string;
+  onCrossClick?: () => void;
+}
+
+const CategoryBadge = ({ emoji, text, className, onCrossClick, ...props }: ICategoryBadgeProps) => {
+  return (
+    <Badge variant="lightest" className={cn('pl-1 pr-0 gap-0', className)} {...props}>
+      <div className="bg-white w-4 h-4 rounded-full p-[3px] mr-1 flex items-center justify-center text-2xs select-none">
+        {emoji}
+      </div>
+      {text}
+      <button className="h-full w-6 flex items-center relative" onClick={onCrossClick}>
+        <Icon icon={CrossIcon} size={2} className="absolute right-2" />
+      </button>
+    </Badge>
+  );
+};
+
+export { CategoryBadge };

--- a/src/features/foods/components/FilterBadge.tsx
+++ b/src/features/foods/components/FilterBadge.tsx
@@ -1,0 +1,44 @@
+import { CrossIcon } from '@/assets/images/icons';
+import { Icon } from '@/components/ui';
+import { Badge } from '@/components/ui/Badge';
+import { cn } from '@/lib/tailwind/utils';
+
+import { ComponentType } from 'react';
+
+interface IFilterBadgeProps {
+  icon?: ComponentType;
+  emoji?: string;
+  text: string;
+  className?: string;
+  onCrossClick?: () => void;
+}
+
+const FilterBadge = ({
+  icon,
+  emoji,
+  text,
+  className,
+  onCrossClick,
+  ...props
+}: IFilterBadgeProps) => {
+  const CircledIcon = icon;
+  return (
+    <Badge variant="light" className={cn('pl-1 pr-0 gap-0', className)} {...props}>
+      {CircledIcon ? (
+        <div className="bg-white w-4 h-4 rounded-full p-[3.5px] mr-1 flex items-center justify-center">
+          <CircledIcon />
+        </div>
+      ) : emoji ? (
+        <div className="bg-white w-4 h-4 rounded-full p-[3px] mr-1 flex items-center justify-center text-2xs select-none">
+          {emoji}
+        </div>
+      ) : null}
+      {text}
+      <button className="h-full w-6 flex items-center relative" onClick={onCrossClick}>
+        <Icon icon={CrossIcon} size={2} className="absolute right-2" />
+      </button>
+    </Badge>
+  );
+};
+
+export { FilterBadge };

--- a/src/features/foods/components/index.ts
+++ b/src/features/foods/components/index.ts
@@ -1,0 +1,1 @@
+export { FilterBadge } from './FilterBadge';

--- a/src/features/foods/components/index.ts
+++ b/src/features/foods/components/index.ts
@@ -1,1 +1,2 @@
+export { CategoryBadge } from './CategoryBadge';
 export { FilterBadge } from './FilterBadge';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,9 @@
 module.exports = {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
+    fontSize: {
+      '2xs': '0.625rem', // 10px
+    },
     extend: {
       colors: {
         'primary-lightest': '#e6f2f1',


### PR DESCRIPTION
## Overviews

This PR introduces the `Badge` component used throughout the project, as well as the `FilterBadge` and `CategoryBadge` components used on the Foods page.

## Review points

- Is defining constants for food categories in `src/const/foodCategory.ts` appropriate? I wonder how we can associate these with the data fetched from the DB.

## Screenshots

<img width="360" alt="image" src="https://github.com/genesis-tech-tribe/nishiki-frontend/assets/99148565/4ed50098-fb5b-46c1-8d65-af93cdf59c11">


## Note
- You can test visually by importing `<BadgeUsageExample>` to some page.
- Although the `<Badge>` component is currently used in the Foods feature, I decided to place it in `src/components/ui/`, the project-scope directory, because the definition of the `Badge` component is very generic.
- I haven't checked what the emojis look like on Android devices
- Still waiting for the designers to define the accurate sizes of the badge, such as icon sizes, paddings, etc.