### PR TITLE
Docs: Fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,8 +1,3 @@
----
-name: Default
-title: 'Write a title according to the naming conventions below'
----
-
 <!--
 
 Title Naming Conventions:

--- a/.github/PULL_REQUEST_TEMPLATE/merge.md
+++ b/.github/PULL_REQUEST_TEMPLATE/merge.md
@@ -1,8 +1,3 @@
----
-name: Merge
-title: 'Merge `develop` to `main`'
----
-
 ## Overview
 
 <!-- Provide an overview of the merge, highlighting the purpose of merging these changes into the base branch. -->


### PR DESCRIPTION
## Overview

Removed the hidden parameters section at the top of each PR template because the PR templates haven't appeared when creating a new PR since merging the PR #109.

## Notes
- We cannot confirm whether this modification works until this PR is merged