### PR TITLE
Added IGroup attribute to container interface

### DIFF
--- a/src/components/page/FoodsPage.tsx
+++ b/src/components/page/FoodsPage.tsx
@@ -38,7 +38,7 @@ export const FoodsPage = ({ containers }: { containers: IContainer[] }) => {
     setCategoryList(categoryList);
     setQuery(searchParams?.get('query') || '');
 
-    const filterByGroup = (row: IContainer) => group === '' || group === row.groupId;
+    const filterByGroup = (row: IContainer) => group === '' || group === row.group.groupId;
     const filterByContainer = (row: IContainer) => container === '' || container === row.id;
     const filterByCategory = (food: IFoodView) => {
       if (!categoryList.length) return true;

--- a/src/components/page/FoodsPage.tsx
+++ b/src/components/page/FoodsPage.tsx
@@ -38,7 +38,7 @@ export const FoodsPage = ({ containers }: { containers: IContainer[] }) => {
     setCategoryList(categoryList);
     setQuery(searchParams?.get('query') || '');
 
-    const filterByGroup = (row: IContainer) => group === '' || group === row.group.groupId;
+    const filterByGroup = (row: IContainer) => group === '' || group === row.group.id;
     const filterByContainer = (row: IContainer) => container === '' || container === row.id;
     const filterByCategory = (food: IFoodView) => {
       if (!categoryList.length) return true;

--- a/src/features/foods/types/FoodTypes.ts
+++ b/src/features/foods/types/FoodTypes.ts
@@ -3,5 +3,5 @@ import { IContainer, IFood } from '@/types/definition';
 export interface IFoodView extends IFood {
   container: string;
 }
-export type GroupIdContainersMapType = Record<IContainer['group']['groupId'], IContainer['id'][]>;
-export type IdNameMapType = Record<IContainer['group']['groupId'], IContainer['id']>;
+export type GroupIdContainersMapType = Record<IContainer['group']['id'], IContainer['id'][]>;
+export type IdNameMapType = Record<IContainer['group']['id'], IContainer['id']>;

--- a/src/features/foods/types/FoodTypes.ts
+++ b/src/features/foods/types/FoodTypes.ts
@@ -3,5 +3,5 @@ import { IContainer, IFood } from '@/types/definition';
 export interface IFoodView extends IFood {
   container: string;
 }
-export type GroupIdContainersMapType = Record<IContainer['groupId'], IContainer['id'][]>;
-export type IdNameMapType = Record<IContainer['groupId'], IContainer['id']>;
+export type GroupIdContainersMapType = Record<IContainer['group']['groupId'], IContainer['id'][]>;
+export type IdNameMapType = Record<IContainer['group']['groupId'], IContainer['id']>;

--- a/src/features/foods/utils/containerMapping.ts
+++ b/src/features/foods/utils/containerMapping.ts
@@ -7,7 +7,7 @@ export const groupContainersByGroupId = (containers: IContainer[]): GroupIdConta
   return containers.reduce(
     (acc, { group, id }) => ({
       ...acc,
-      [group.groupId]: acc[group.groupId] ? [...acc[group.groupId], id] : [id],
+      [group.id]: acc[group.id] ? [...acc[group.id], id] : [id],
     }),
     {} as GroupIdContainersMapType,
   );
@@ -27,8 +27,8 @@ export const createContainerIdNameMap = (containers: IContainer[]): ContainerIdN
 export const createGroupIdNameMap = (containers: IContainer[]): GroupIdNameMapType => {
   const groupIdGroupNameMap: { [key: string]: string } = {};
   containers.forEach((c) => {
-    if (!groupIdGroupNameMap[c.group.groupId]) {
-      groupIdGroupNameMap[c.group.groupId] = c.group.groupName;
+    if (!groupIdGroupNameMap[c.group.id]) {
+      groupIdGroupNameMap[c.group.id] = c.group.name;
     }
   });
   return groupIdGroupNameMap;

--- a/src/features/foods/utils/containerMapping.ts
+++ b/src/features/foods/utils/containerMapping.ts
@@ -5,9 +5,9 @@ import { IdNameMapType } from '../types/FoodTypes';
 
 export const groupContainersByGroupId = (containers: IContainer[]): GroupIdContainersMapType => {
   return containers.reduce(
-    (acc, { groupId, id }) => ({
+    (acc, { group, id }) => ({
       ...acc,
-      [groupId]: acc[groupId] ? [...acc[groupId], id] : [id],
+      [group.groupId]: acc[group.groupId] ? [...acc[group.groupId], id] : [id],
     }),
     {} as GroupIdContainersMapType,
   );
@@ -27,8 +27,8 @@ export const createContainerIdNameMap = (containers: IContainer[]): ContainerIdN
 export const createGroupIdNameMap = (containers: IContainer[]): GroupIdNameMapType => {
   const groupIdGroupNameMap: { [key: string]: string } = {};
   containers.forEach((c) => {
-    if (!groupIdGroupNameMap[c.groupId]) {
-      groupIdGroupNameMap[c.groupId] = c.groupName;
+    if (!groupIdGroupNameMap[c.group.groupId]) {
+      groupIdGroupNameMap[c.group.groupId] = c.group.groupName;
     }
   });
   return groupIdGroupNameMap;

--- a/src/features/groups/components/GroupItem.tsx
+++ b/src/features/groups/components/GroupItem.tsx
@@ -8,12 +8,12 @@ import { ContainerCount } from './ContainerCount';
 import { UserCount } from './UserCount';
 
 export const GroupItem = async ({ group }: { group: IGroup }) => {
-  const containers: IContainer[] = await fetchContainerList(group.groupId);
-  const users: IUser[] = await fetchUserList(group.groupId);
+  const containers: IContainer[] = await fetchContainerList(group.id);
+  const users: IUser[] = await fetchUserList(group.id);
   return (
-    <Link href={`/groups/${group.groupId}`} key={group.groupId}>
-      <span>{group.groupId} </span>
-      <span>{group.groupName} </span>
+    <Link href={`/groups/${group.id}`} key={group.id}>
+      <span>{group.id} </span>
+      <span>{group.name} </span>
       <ContainerCount containerCount={containers.length} />
       <UserCount userCount={users.length} />
     </Link>

--- a/src/features/groups/components/GroupList.tsx
+++ b/src/features/groups/components/GroupList.tsx
@@ -6,7 +6,7 @@ export const GroupList = async ({ groups }: { groups: IGroup[] }) => {
   return (
     <>
       {groups.map((group) => (
-        <GroupItem key={group.groupId} group={group} />
+        <GroupItem key={group.id} group={group} />
       ))}
     </>
   );

--- a/src/types/definition.ts
+++ b/src/types/definition.ts
@@ -11,8 +11,7 @@ export interface IUser {
 export interface IContainer {
   id: string;
   name: string;
-  groupId: string;
-  groupName: string;
+  group: IGroup;
   foods: IFood[];
 }
 

--- a/src/types/definition.ts
+++ b/src/types/definition.ts
@@ -1,6 +1,6 @@
 export interface IGroup {
-  groupId: string;
-  groupName: string;
+  id: string;
+  name: string;
 }
 
 export interface IUser {


### PR DESCRIPTION
## Overview

- Added IGroup attribute to IContainer interface instead of using groupId, groupName directly.
- Corrected to reference IContainer's IGroup.
- Name convention of from groupId to id groupName to name
