### PR TITLE
Add igroup attribute to container interface

### DIFF
--- a/src/components/page/FoodsPage.tsx
+++ b/src/components/page/FoodsPage.tsx
@@ -38,7 +38,7 @@ export const FoodsPage = ({ containers }: { containers: IContainer[] }) => {
     setCategoryList(categoryList);
     setQuery(searchParams?.get('query') || '');
 
-    const filterByGroup = (row: IContainer) => group === '' || group === row.groupId;
+    const filterByGroup = (row: IContainer) => group === '' || group === row.group.groupId;
     const filterByContainer = (row: IContainer) => container === '' || container === row.id;
     const filterByCategory = (food: IFoodView) => {
       if (!categoryList.length) return true;

--- a/src/components/page/FoodsPage.tsx
+++ b/src/components/page/FoodsPage.tsx
@@ -38,7 +38,7 @@ export const FoodsPage = ({ containers }: { containers: IContainer[] }) => {
     setCategoryList(categoryList);
     setQuery(searchParams?.get('query') || '');
 
-    const filterByGroup = (row: IContainer) => group === '' || group === row.group.groupId;
+    const filterByGroup = (row: IContainer) => group === '' || group === row.group.id;
     const filterByContainer = (row: IContainer) => container === '' || container === row.id;
     const filterByCategory = (food: IFoodView) => {
       if (!categoryList.length) return true;

--- a/src/features/foods/components/FoodFilterCategoryDrawer.tsx
+++ b/src/features/foods/components/FoodFilterCategoryDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TriangleRightIcon } from '@/assets/images/icons';
+import { CaretRightIcon } from '@/assets/images/icons';
 import {
   DrawerBody,
   DrawerContent,
@@ -29,7 +29,7 @@ export const FoodFilterCategoryDrawer = ({
         <DrawerTrigger asChild>
           <div className="flex items-center">
             Category
-            <Icon icon={TriangleRightIcon} className="absolute right-6" />
+            <Icon icon={CaretRightIcon} className="absolute right-6" />
           </div>
         </DrawerTrigger>
         <DrawerContent side="right">

--- a/src/features/foods/components/FoodSort.tsx
+++ b/src/features/foods/components/FoodSort.tsx
@@ -1,4 +1,4 @@
-import { TriangleDownIcon } from '@/assets/images/icons';
+import { CaretRightIcon } from '@/assets/images/icons';
 import {
   Icon,
   Label,
@@ -49,7 +49,7 @@ export const FoodSort = () => {
         <SelectionDrawerTrigger asChild>
           <button className="flex items-center">
             {sortOptions[selectedOption as keyof typeof sortOptions]}
-            <Icon icon={TriangleDownIcon} className="m-5" />
+            <Icon icon={CaretRightIcon} className="m-5" />
           </button>
         </SelectionDrawerTrigger>
         <SelectionDrawerContent>

--- a/src/features/foods/components/FoodSort.tsx
+++ b/src/features/foods/components/FoodSort.tsx
@@ -1,4 +1,4 @@
-import { CaretRightIcon } from '@/assets/images/icons';
+import { CaretDownIcon } from '@/assets/images/icons';
 import {
   Icon,
   Label,
@@ -49,7 +49,7 @@ export const FoodSort = () => {
         <SelectionDrawerTrigger asChild>
           <button className="flex items-center">
             {sortOptions[selectedOption as keyof typeof sortOptions]}
-            <Icon icon={CaretRightIcon} className="m-5" />
+            <Icon icon={CaretDownIcon} className="m-5" />
           </button>
         </SelectionDrawerTrigger>
         <SelectionDrawerContent>

--- a/src/features/foods/types/FoodTypes.ts
+++ b/src/features/foods/types/FoodTypes.ts
@@ -3,5 +3,5 @@ import { IContainer, IFood } from '@/types/definition';
 export interface IFoodView extends IFood {
   container: string;
 }
-export type GroupIdContainersMapType = Record<IContainer['group']['groupId'], IContainer['id'][]>;
-export type IdNameMapType = Record<IContainer['group']['groupId'], IContainer['id']>;
+export type GroupIdContainersMapType = Record<IContainer['group']['id'], IContainer['id'][]>;
+export type IdNameMapType = Record<IContainer['group']['id'], IContainer['id']>;

--- a/src/features/foods/types/FoodTypes.ts
+++ b/src/features/foods/types/FoodTypes.ts
@@ -3,5 +3,5 @@ import { IContainer, IFood } from '@/types/definition';
 export interface IFoodView extends IFood {
   container: string;
 }
-export type GroupIdContainersMapType = Record<IContainer['groupId'], IContainer['id'][]>;
-export type IdNameMapType = Record<IContainer['groupId'], IContainer['id']>;
+export type GroupIdContainersMapType = Record<IContainer['group']['groupId'], IContainer['id'][]>;
+export type IdNameMapType = Record<IContainer['group']['groupId'], IContainer['id']>;

--- a/src/features/foods/utils/containerMapping.ts
+++ b/src/features/foods/utils/containerMapping.ts
@@ -7,7 +7,7 @@ export const groupContainersByGroupId = (containers: IContainer[]): GroupIdConta
   return containers.reduce(
     (acc, { group, id }) => ({
       ...acc,
-      [group.groupId]: acc[group.groupId] ? [...acc[group.groupId], id] : [id],
+      [group.id]: acc[group.id] ? [...acc[group.id], id] : [id],
     }),
     {} as GroupIdContainersMapType,
   );
@@ -27,8 +27,8 @@ export const createContainerIdNameMap = (containers: IContainer[]): ContainerIdN
 export const createGroupIdNameMap = (containers: IContainer[]): GroupIdNameMapType => {
   const groupIdGroupNameMap: { [key: string]: string } = {};
   containers.forEach((c) => {
-    if (!groupIdGroupNameMap[c.group.groupId]) {
-      groupIdGroupNameMap[c.group.groupId] = c.group.groupName;
+    if (!groupIdGroupNameMap[c.group.id]) {
+      groupIdGroupNameMap[c.group.id] = c.group.name;
     }
   });
   return groupIdGroupNameMap;

--- a/src/features/foods/utils/containerMapping.ts
+++ b/src/features/foods/utils/containerMapping.ts
@@ -5,9 +5,9 @@ import { IdNameMapType } from '../types/FoodTypes';
 
 export const groupContainersByGroupId = (containers: IContainer[]): GroupIdContainersMapType => {
   return containers.reduce(
-    (acc, { groupId, id }) => ({
+    (acc, { group, id }) => ({
       ...acc,
-      [groupId]: acc[groupId] ? [...acc[groupId], id] : [id],
+      [group.groupId]: acc[group.groupId] ? [...acc[group.groupId], id] : [id],
     }),
     {} as GroupIdContainersMapType,
   );
@@ -27,8 +27,8 @@ export const createContainerIdNameMap = (containers: IContainer[]): ContainerIdN
 export const createGroupIdNameMap = (containers: IContainer[]): GroupIdNameMapType => {
   const groupIdGroupNameMap: { [key: string]: string } = {};
   containers.forEach((c) => {
-    if (!groupIdGroupNameMap[c.groupId]) {
-      groupIdGroupNameMap[c.groupId] = c.groupName;
+    if (!groupIdGroupNameMap[c.group.groupId]) {
+      groupIdGroupNameMap[c.group.groupId] = c.group.groupName;
     }
   });
   return groupIdGroupNameMap;

--- a/src/features/groups/components/GroupItem.tsx
+++ b/src/features/groups/components/GroupItem.tsx
@@ -8,12 +8,12 @@ import { ContainerCount } from './ContainerCount';
 import { UserCount } from './UserCount';
 
 export const GroupItem = async ({ group }: { group: IGroup }) => {
-  const containers: IContainer[] = await fetchContainerList(group.groupId);
-  const users: IUser[] = await fetchUserList(group.groupId);
+  const containers: IContainer[] = await fetchContainerList(group.id);
+  const users: IUser[] = await fetchUserList(group.id);
   return (
-    <Link href={`/groups/${group.groupId}`} key={group.groupId}>
-      <span>{group.groupId} </span>
-      <span>{group.groupName} </span>
+    <Link href={`/groups/${group.id}`} key={group.id}>
+      <span>{group.id} </span>
+      <span>{group.name} </span>
       <ContainerCount containerCount={containers.length} />
       <UserCount userCount={users.length} />
     </Link>

--- a/src/features/groups/components/GroupList.tsx
+++ b/src/features/groups/components/GroupList.tsx
@@ -6,7 +6,7 @@ export const GroupList = async ({ groups }: { groups: IGroup[] }) => {
   return (
     <>
       {groups.map((group) => (
-        <GroupItem key={group.groupId} group={group} />
+        <GroupItem key={group.id} group={group} />
       ))}
     </>
   );

--- a/src/lib/api/data.ts
+++ b/src/lib/api/data.ts
@@ -4,8 +4,13 @@ import axios from 'axios';
 
 const APIDOMAIN = 'http://localhost:8080';
 
+export interface IGroupApiResponse {
+  groupId: string;
+  groupName: string;
+}
+
 interface IGroupsResponse {
-  groups: IGroup[];
+  groups: IGroupApiResponse[];
 }
 
 interface IContainersResponse {
@@ -19,7 +24,10 @@ interface IUsersResponse {
 export async function fetchGroupList(): Promise<IGroup[]> {
   try {
     const res = await axios.get<IGroupsResponse>(APIDOMAIN + '/groups');
-    return res.data.groups;
+    return res.data.groups.map((group) => ({
+      id: group.groupId,
+      name: group.groupName,
+    }));
   } catch (err) {
     throw new Error('API response is invalid');
   }

--- a/src/types/definition.ts
+++ b/src/types/definition.ts
@@ -11,8 +11,7 @@ export interface IUser {
 export interface IContainer {
   id: string;
   name: string;
-  groupId: string;
-  groupName: string;
+  group: IGroup;
   foods: IFood[];
 }
 

--- a/src/types/definition.ts
+++ b/src/types/definition.ts
@@ -1,6 +1,6 @@
 export interface IGroup {
-  groupId: string;
-  groupName: string;
+  id: string;
+  name: string;
 }
 
 export interface IUser {


### PR DESCRIPTION
## Overview

- Added IGroup attribute to IContainer interface instead of using groupId, groupName directly.

## Changes

- Added IGroup attribute to IContainer interface
- Corrected to reference IContainer's IGroup.
- Name convention of from groupId to id, groupName to name


## Assignee Checklist:

<!-- You can tick the checkboxes if not applicable -->

- [x] The base branch is correct (See: [Types of Branches](https://github.com/genesis-tech-tribe/nishiki-frontend/blob/develop/docs/CONTRIBUTING.md#types-of-branches))
- [x] The branch name follows the [Branch Naming Conventions](https://github.com/genesis-tech-tribe/nishiki-frontend/blob/develop/docs/CONTRIBUTING.md#branch-naming-conventions)
- [x] The correct assignees and reviewers have been designated for this PR
- [x] The coding style follows the [Coding Style Guide](https://github.com/genesis-tech-tribe/nishiki-frontend/blob/develop/docs/STYLEGUIDE.md)
- [x] All the related issues are associated with this PR
- [x] All criteria in the associated issues are met (please tick the checkboxes)
- [x] My changes do not generate new warnings or errors (especially in the console)

## Reviewer Checklist:

<!-- You can tick the checkboxes if not applicable -->

- [x] The code follows the generic best practices and our [Coding Style Guide](https://github.com/genesis-tech-tribe/nishiki-frontend/blob/develop/docs/STYLEGUIDE.md)
- [x] Code is well-commented and easy to understand
- [x] UI changes accurately reflect the provided design
